### PR TITLE
Works around the deprication of Protected Attributes in Rails4

### DIFF
--- a/lib/zuul.rb
+++ b/lib/zuul.rb
@@ -8,6 +8,22 @@ module Zuul
   def self.configure(&block)
     @@configuration.configure &block
   end
+  
+  def self.should_whitelist?
+    rails3? or rails4? && protected_attribtues?
+  end
+  
+  def self.rails3?
+    3 == Rails::VERSION::MAJOR
+  end
+  
+  def self.rails4?
+    4== Rails::VERSION::MAJOR
+  end
+
+  def self.protected_attribtues?
+    defined? ::ProtectedAttributes
+  end
 end
 
 require 'zuul/context'

--- a/lib/zuul/active_record.rb
+++ b/lib/zuul/active_record.rb
@@ -268,7 +268,8 @@ module Zuul
     # to provide easy access to the context for that object.
     module ContextMethods
       def self.included(base)
-        base.send :attr_accessible, :context
+        base.send :attr_accessible, :context if ::Zuul
+.should_whitelist?
       end
 
       # Return a Zuul::Context object representing the context for the role

--- a/lib/zuul/active_record/permission.rb
+++ b/lib/zuul/active_record/permission.rb
@@ -8,7 +8,8 @@ module Zuul
 
       module ClassMethods
         def self.extended(base)
-          base.send :attr_accessible, :context, :context_id, :context_type, :slug
+          base.send :attr_accessible, :context, :context_id, :context_type, :slug if ::Zuul
+.should_whitelist?
           add_validations base
           add_associations base
         end

--- a/lib/zuul/active_record/permission_role.rb
+++ b/lib/zuul/active_record/permission_role.rb
@@ -8,7 +8,8 @@ module Zuul
 
       module ClassMethods
         def self.extended(base)
-          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.permission_foreign_key.to_sym, base.auth_scope.role_foreign_key.to_sym
+          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.permission_foreign_key.to_sym, base.auth_scope.role_foreign_key.to_sym if ::Zuul
+.should_whitelist?
           add_validations base
           add_associations base
         end

--- a/lib/zuul/active_record/permission_subject.rb
+++ b/lib/zuul/active_record/permission_subject.rb
@@ -8,7 +8,8 @@ module Zuul
 
       module ClassMethods
         def self.extended(base)
-          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.permission_foreign_key.to_sym, base.auth_scope.subject_foreign_key.to_sym
+          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.permission_foreign_key.to_sym, base.auth_scope.subject_foreign_key.to_sym if ::Zuul
+.should_whitelist?
           add_validations base
           add_associations base
         end

--- a/lib/zuul/active_record/role.rb
+++ b/lib/zuul/active_record/role.rb
@@ -9,7 +9,8 @@ module Zuul
 
       module ClassMethods
         def self.extended(base)
-          base.send :attr_accessible, :context_id, :context_type, :level, :slug
+          base.send :attr_accessible, :context_id, :context_type, :level, :slug if ::Zuul
+.should_whitelist?
           add_validations base
           add_associations base
         end

--- a/lib/zuul/active_record/role_subject.rb
+++ b/lib/zuul/active_record/role_subject.rb
@@ -8,7 +8,8 @@ module Zuul
 
       module ClassMethods
         def self.extended(base)
-          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.role_foreign_key.to_sym, base.auth_scope.subject_foreign_key.to_sym
+          base.send :attr_accessible, :context, :context_id, :context_type, base.auth_scope.role_foreign_key.to_sym, base.auth_scope.subject_foreign_key.to_sym if ::Zuul
+.should_whitelist?
           add_validations base
           add_associations base
         end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,17 +1,20 @@
 # Default Subject, Role, Permission and Context models
 Object.send(:remove_const, :User) if defined?(User) # we do this to undefine the model and start fresh, without any of the authorization stuff applied by tests
 class User < ActiveRecord::Base
-  attr_accessible :name
+  attr_accessible :name if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Role) if defined?(Role)
 class Role < ActiveRecord::Base
-  attr_accessible :name, :slug, :level, :context_type, :context_id
+  attr_accessible :name, :slug, :level, :context_type, :context_id if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Permission) if defined?(Permission)
 class Permission < ActiveRecord::Base
-  attr_accessible :name, :slug, :context_type, :context_id
+  attr_accessible :name, :slug, :context_type, :context_id if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Context) if defined?(Context)
@@ -51,17 +54,20 @@ end
 # Custom named Subject, Role, Permission and Context models
 Object.send(:remove_const, :Soldier) if defined?(Soldier)
 class Soldier < ActiveRecord::Base
-  attr_accessible :name
+  attr_accessible :name if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Rank) if defined?(Rank)
 class Rank < ActiveRecord::Base
-  attr_accessible :name, :slug, :level, :context_type, :context_id
+  attr_accessible :name, :slug, :level, :context_type, :context_id if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Skill) if defined?(Skill)
 class Skill < ActiveRecord::Base
-  attr_accessible :name, :slug, :context_type, :context_id
+  attr_accessible :name, :slug, :context_type, :context_id if ::Zuul
+.should_whitelist?
 end
 
 Object.send(:remove_const, :Weapon) if defined?(Weapon)
@@ -100,17 +106,20 @@ module ZuulModels
 
   send(:remove_const, :User) if defined?(ZuulModels::User)
   class User < ActiveRecord::Base
-    attr_accessible :name
+    attr_accessible :name if ::Zuul
+.should_whitelist?
   end
 
   send(:remove_const, :Role) if defined?(ZuulModels::Role)
   class Role < ActiveRecord::Base
-    attr_accessible :name, :slug, :level, :context_type, :context_id
+    attr_accessible :name, :slug, :level, :context_type, :context_id if ::Zuul
+.should_whitelist?
   end
 
   send(:remove_const, :Permission) if defined?(ZuulModels::Permission)
   class Permission < ActiveRecord::Base
-    attr_accessible :name, :slug, :context_type, :context_id
+    attr_accessible :name, :slug, :context_type, :context_id if ::Zuul
+.should_whitelist?
   end
 
   send(:remove_const, :Context) if defined?(ZuulModels::Context)


### PR DESCRIPTION
- Adds `Zuul.rails3?`, `Zuul.rails4?`, and `Zuul.protected_attributes?` to detect rails version and whether or not the protected_attributes gem is installed.
- Adds `Zuul.should_whitelist?` to roll up the logic determining whether Zuul should inject `attr_accessable` calls.
- Liberally checks `Zuul.should_whitelist?` before injecting said calls.
