### PR TITLE
Migrations generators fix

### DIFF
--- a/lib/generators/zuul/permission_generator.rb
+++ b/lib/generators/zuul/permission_generator.rb
@@ -15,9 +15,9 @@ module ActiveRecord
 
         def copy_zuul_migration
           if (behavior == :invoke && model_exists?) || (behavior == :revoke && migration_exists?(:permission, table_name))
-            migration_template "permission_existing.rb", "db/migrate/add_zuul_permission_to_#{table_name}"
+            migration_template "permission_existing.rb", "db/migrate/add_zuul_permission_to_#{table_name}.rb"
           else
-            migration_template "permission.rb", "db/migrate/zuul_permission_create_#{table_name}"
+            migration_template "permission.rb", "db/migrate/zuul_permission_create_#{table_name}.rb"
           end
         end
 

--- a/lib/generators/zuul/permission_role_generator.rb
+++ b/lib/generators/zuul/permission_role_generator.rb
@@ -17,17 +17,17 @@ module ActiveRecord
         def name
           [permission_model, role_model].sort.map(&:to_s).map(&:camelize).map(&:singularize).join("")
         end
-        
+
         def copy_permission_role_migration
           attributes << Rails::Generators::GeneratedAttribute.new("#{permission_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("#{role_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("context_type", :string)
           attributes << Rails::Generators::GeneratedAttribute.new("context_id", :integer)
-          
+
           if (behavior == :invoke && model_exists?) || (behavior == :revoke && migration_exists?(:permission_role, table_name))
-            migration_template "permission_role_existing.rb", "db/migrate/add_zuul_permission_role_to_#{table_name}"
+            migration_template "permission_role_existing.rb", "db/migrate/add_zuul_permission_role_to_#{table_name}.rb"
           else
-            migration_template "permission_role.rb", "db/migrate/zuul_permission_role_create_#{table_name}"
+            migration_template "permission_role.rb", "db/migrate/zuul_permission_role_create_#{table_name}.rb"
           end
         end
 

--- a/lib/generators/zuul/permission_subject_generator.rb
+++ b/lib/generators/zuul/permission_subject_generator.rb
@@ -17,17 +17,17 @@ module ActiveRecord
         def name
           [permission_model, subject_model].sort.map(&:to_s).map(&:camelize).map(&:singularize).join("")
         end
-        
+
         def copy_permission_subject_migration
           attributes << Rails::Generators::GeneratedAttribute.new("#{permission_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("#{subject_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("context_type", :string)
           attributes << Rails::Generators::GeneratedAttribute.new("context_id", :integer)
-          
+
           if (behavior == :invoke && model_exists?) || (behavior == :revoke && migration_exists?(:permission_subject, table_name))
-            migration_template "permission_subject_existing.rb", "db/migrate/add_zuul_permission_subject_to_#{table_name}"
+            migration_template "permission_subject_existing.rb", "db/migrate/add_zuul_permission_subject_to_#{table_name}.rb"
           else
-            migration_template "permission_subject.rb", "db/migrate/zuul_permission_subject_create_#{table_name}"
+            migration_template "permission_subject.rb", "db/migrate/zuul_permission_subject_create_#{table_name}.rb"
           end
         end
 

--- a/lib/generators/zuul/role_generator.rb
+++ b/lib/generators/zuul/role_generator.rb
@@ -12,12 +12,12 @@ module ActiveRecord
 
         include ::Zuul::Generators::OrmHelpers
         source_root File.expand_path("../templates", __FILE__)
-        
+
         def copy_role_migration
           if (behavior == :invoke && model_exists?) || (behavior == :revoke && migration_exists?(:role, table_name))
-            migration_template "role_existing.rb", "db/migrate/add_zuul_role_to_#{table_name}"
+            migration_template "role_existing.rb", "db/migrate/add_zuul_role_to_#{table_name}.rb"
           else
-            migration_template "role.rb", "db/migrate/zuul_role_create_#{table_name}"
+            migration_template "role.rb", "db/migrate/zuul_role_create_#{table_name}.rb"
           end
         end
 

--- a/lib/generators/zuul/role_subject_generator.rb
+++ b/lib/generators/zuul/role_subject_generator.rb
@@ -17,17 +17,17 @@ module ActiveRecord
         def name
           [role_model, subject_model].sort.map(&:to_s).map(&:camelize).map(&:singularize).join("")
         end
-        
+
         def copy_role_subject_migration
           attributes << Rails::Generators::GeneratedAttribute.new("#{role_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("#{subject_model.to_s.underscore.singularize}_id", :integer)
           attributes << Rails::Generators::GeneratedAttribute.new("context_type", :string)
           attributes << Rails::Generators::GeneratedAttribute.new("context_id", :integer)
-          
+
           if (behavior == :invoke && model_exists?) || (behavior == :revoke && migration_exists?(:role_subject, table_name))
-            migration_template "role_subject_existing.rb", "db/migrate/add_zuul_role_subject_to_#{table_name}"
+            migration_template "role_subject_existing.rb", "db/migrate/add_zuul_role_subject_to_#{table_name}.rb"
           else
-            migration_template "role_subject.rb", "db/migrate/zuul_role_subject_create_#{table_name}"
+            migration_template "role_subject.rb", "db/migrate/zuul_role_subject_create_#{table_name}.rb"
           end
         end
 


### PR DESCRIPTION
When using `rails generate zuul:role Role name:string` and, in general, all other generators, the created migration file was without extension.
I just added it.

Anyway, I'd like to help you to improve this gem, because I like it very much!
